### PR TITLE
QA: SEMI-1213 Open drawer with null printerId

### DIFF
--- a/public/ts/tests/TestOpenCashDrawerRequestNullPrinterId.ts
+++ b/public/ts/tests/TestOpenCashDrawerRequestNullPrinterId.ts
@@ -1,0 +1,68 @@
+import * as sdk from 'remote-pay-cloud-api';
+import * as Clover from 'remote-pay-cloud';
+import {TestBase2} from '../base/TestBase2';
+import {ExampleCloverConnectorListener} from '../base/ExampleCloverConnectorListener';
+import {CloverConfigLoader} from '../configurationLoader/CloverConfigLoader';
+
+export class TestOpenCashDrawerRequestNullPrinterId extends TestBase2 {
+
+    constructor(loader: CloverConfigLoader, progressInfoCallback: any) {
+        super(loader, progressInfoCallback);
+    }
+
+    /**
+     *
+     */
+    public getName(): string {
+        return "Test Opening the default cash drawer on a printer with a null Id";
+    }
+
+    /**
+     * Method to get the connector listener for this test
+     *
+     * @override
+     * @param cloverConnector
+     * @param progressInfoCallback
+     */
+    public getCloverConnectorListener(cloverConnector: Clover.CloverConnector, progressInfoCallback: any): sdk.remotepay.ICloverConnectorListener {
+        let connectorListener: TestOpenCashDrawerRequestNullPrinterId.CloverConnectorListener = new TestOpenCashDrawerRequestNullPrinterId.CloverConnectorListener(cloverConnector, progressInfoCallback);
+        return connectorListener;
+    }
+}
+
+export namespace TestOpenCashDrawerRequestNullPrinterId {
+    export class CloverConnectorListener extends ExampleCloverConnectorListener {
+
+        /**
+         * Used to identify the test in progress messages.
+         *
+         * @override
+         * @returns {string}
+         */
+        protected getTestName(): string {
+            return "Test Opening the default cash drawer on a printer with a null Id";
+        }
+
+        /**
+         * @override
+         */
+        protected startTest(): void {
+            super.startTest();
+            /*
+             The connector is ready, you can use it to communicate with the device.
+             */
+            this.displayMessage({message: "Call open cash drawer"});
+            let request:sdk.remotepay.OpenCashDrawerRequest = new sdk.remotepay.OpenCashDrawerRequest();
+            request.setReason(null);
+
+            request.setDeviceId(null);
+
+            this.cloverConnector.openCashDrawer(request);
+            setTimeout(function () {
+                // Always call this when your test is done, or the device may fail to connect the
+                // next time, because it is already connected.
+                this.testComplete(true);
+            }.bind(this), 5000);
+        }
+    }
+}

--- a/public/ts/tests/index.ts
+++ b/public/ts/tests/index.ts
@@ -68,6 +68,8 @@ export {TestSaleTippableAmount} from "./TestSaleTippableAmount";
 export {TestOpenCashDrawerCall} from "./TestOpenCashDrawerCall";
 export {TestOpenCashDrawerRequest} from "./TestOpenCashDrawerRequest";
 export {TestOpenCashDrawerCallNullMessage} from "./TestOpenCashDrawerCallNullMessage";
+export {TestOpenCashDrawerRequestNullPrinterId} from "./TestOpenCashDrawerRequestNullPrinterId";
+
 export {TestRetrievePrinters} from "./TestRetrievePrinters";
 export {TestRetrievePrintJobStatus} from "./TestRetrievePrintJobStatus";
 export {TestBadIDRetrievePrintJobStatus} from "./TestBadIDRetrievePrintJobStatus";


### PR DESCRIPTION
The JIRA that prompted this involved a null ID on a required printer paramter.  Since its creation, that parameter is no longer needed.  There is, however, the option to set an device ID--which is the closest thing we now have (per @mike-clover-com).

This PR adds a test which sets the device ID to null and then opens the cash drawer.